### PR TITLE
Don't show submenu in navigation on IE (#3)

### DIFF
--- a/_sass/navbar.scss
+++ b/_sass/navbar.scss
@@ -92,6 +92,12 @@ $sub-item-height: 40px;
                 // Do not expand menus on touch centric devices.
                 display: none !important;
             }
+
+            @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+                // CSS Hack to apply only on IE 10 and 11
+                // See https://stackoverflow.com/questions/18907131/detecting-ie11-using-css-capability-feature-detection
+                display: none !important;
+            }
         }
     }
 


### PR DESCRIPTION
雑なIE対応として、ナビゲーションのサブメニューをIEでは表示しないようにする。

part of #3.

@numa72 Windows実機が今手元に無いので、IE ではナビゲーションが隠され、 Edge には影響がなく動いているか確認していただけないでしょうか。