### PR TITLE
Specify line-height in pager link to workaround font height issue

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -557,6 +557,7 @@ ruby {
       display: inline-block;
       padding: 8px 12px;
       text-decoration: none;
+      line-height: 1.5em;
 
       background: white;
       color: #303030;


### PR DESCRIPTION
英字フォントと日本語フォントの高さが異なる場合に、issueのような問題が発生してしまう。 line-heightを指定することで問題を回避する。

Fixes #58.