### PR TITLE
次回試合予定（2024春）の追加

### DIFF
--- a/_data/next-games.yml
+++ b/_data/next-games.yml
@@ -1,0 +1,6 @@
+- name: 令和6年度 春季大会 WEEK2
+  date: 2024年4月21日
+  start_at: "12:30"
+  place: 早大東伏見グラウンド
+  vs: 未定
+  url: /topics/2024/03-10-spring-tokyo-games.html


### PR DESCRIPTION
トップページの「GAME SCHEDULE」に、春の初戦の告知を追加します。 #90  でやり忘れていました。